### PR TITLE
feat: add line-number to templateSimpleExpression output 

### DIFF
--- a/src/rules/vue-strong/templateSimpleExpression.test.ts
+++ b/src/rules/vue-strong/templateSimpleExpression.test.ts
@@ -22,17 +22,20 @@ describe('checkTemplateSimpleExpression', () => {
   it('should report files where template expression is not simple', () => {
     const script = {
       content: `<template>
-      {{
-        fullName.split(' ').map((word) => {
-            return word[0].toUpperCase() + word.slice(1)
-        }).join(' ')
-      }}
-    </template>`,
+        <div>
+          {{
+            fullName.split(' ').filter((word, idx) => word).map((word) => {
+                return word[0].toUpperCase() + word.slice(1)
+            }).join(' ')
+          }}
+        </div>
+      </template>`,
     } as SFCTemplateBlock
     const fileName = 'not-simple-expression.vue'
+    const lineNumber = 4;
     checkTemplateSimpleExpression(script, fileName)
     expect(reportTemplateSimpleExpression()).toBe(1)
     expect(mockConsoleLog).toHaveBeenCalled()
-    expect(mockConsoleLog).toHaveBeenLastCalledWith(`- ${fileName} 🚨`)
+    expect(mockConsoleLog).toHaveBeenLastCalledWith(`- ${fileName} (Line ${lineNumber}) 🚨`)
   })
 })

--- a/src/rules/vue-strong/templateSimpleExpression.ts
+++ b/src/rules/vue-strong/templateSimpleExpression.ts
@@ -1,7 +1,7 @@
 import { SFCTemplateBlock } from '@vue/compiler-sfc'
 import { BG_RESET, TEXT_WARN, TEXT_RESET, BG_ERR, TEXT_INFO } from '../asceeCodes'
 
-const templateSimpleExpressionFiles: { filePath: string }[] = []
+const templateSimpleExpressionFiles: { filePath: string, lineNumber: number }[] = []
 
 const MAX_EXPRESSION_LENGTH = 40 // completely made-up number
 
@@ -9,11 +9,26 @@ const checkTemplateSimpleExpression = (template: SFCTemplateBlock, filePath: str
   const regex = /{{\s*([\s\S]*?)\s*}}/g
   const matches = [...template.content.matchAll(regex)].map(match => match[1].trim())
 
+  let accumulativeLength = 0;
+  const lines = template.content.split('\n');
+
   matches.forEach(expression => {
     if (expression.length > MAX_EXPRESSION_LENGTH) {
+      // Calculate the starting index of the expression
+      const expressionStartIdx = template.content.indexOf(expression);
+      let expressionStartLine = 1;
+
+      for (let i = 0; i < lines.length; i++) {
+        accumulativeLength += lines[i].length + 1; // +1 for the newline character
+        if (accumulativeLength > expressionStartIdx) {
+          expressionStartLine = i + 1;
+          break;
+        }
+      }
+      
       //if this file is not in the array yet, push it
-      if (!templateSimpleExpressionFiles.some(file => file.filePath === filePath)) {
-        templateSimpleExpressionFiles.push({ filePath })
+      if (!templateSimpleExpressionFiles.some(file => file.filePath === filePath && file.lineNumber === expressionStartLine)) {
+        templateSimpleExpressionFiles.push({ filePath, lineNumber: expressionStartLine })
       }
     }
   })
@@ -28,7 +43,7 @@ const reportTemplateSimpleExpression = () => {
       `👉 ${TEXT_WARN}Refactor the expression into a computed property.${TEXT_RESET} See: https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates`
     )
     templateSimpleExpressionFiles.forEach(file => {
-      console.log(`- ${file.filePath} 🚨`)
+      console.log(`- ${file.filePath} (Line ${file.lineNumber}) 🚨`)
     })
   }
   return templateSimpleExpressionFiles.length


### PR DESCRIPTION
In this PR, I:
1. Changed the `content` of the `not-simple-expression.vue` just for testing.
2. Added `(Line ${lineNumber})` to the final console log in the `not-simple-expression.vue` test.
3. Added the logic to obtain the `lineNumber` for each `expression` in `matches` array.

I couldn't get to test the feture as an end user, I tried both ways @rrd108 recommended in #54 but I didn't get anywhere. But using `Debug: JavaScript Debug Terminal` I could follow the lineNumber calculation and I checked with multiple cases and it seems to work.
![Screenshot 2024-07-12 095634](https://github.com/user-attachments/assets/4a51f78d-76da-42b2-ab37-d1daa9421af2)

I'll leave this as a Draft PR just because I couldn't verify it that way