### PR TITLE
fix: fileCount in output was counting duplicates

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,5 @@
+// Helper function to count non duplicated objects (using `field` to filter)
+export function getUniqueFilenameCount<T>(arr: T[], field: Partial<keyof T>): number {
+  const uniqueFilenames = new Set(arr.map((item) => item[field]));
+  return uniqueFilenames.size;
+}

--- a/src/rules/rrd/functionSize.ts
+++ b/src/rules/rrd/functionSize.ts
@@ -1,7 +1,13 @@
 import { SFCScriptBlock } from '@vue/compiler-sfc';
 import { BG_RESET, BG_WARN, TEXT_WARN, TEXT_RESET, TEXT_INFO } from '../asceeCodes'
+import { getUniqueFilenameCount } from '../../helpers';
 
-const functionSizeFiles: { filename: string, funcName: string }[] = [];
+type FunctionSizeFile = {
+  filename: string;
+  funcName: string
+};
+
+const functionSizeFiles: FunctionSizeFile[] = [];
 
 const MAX_FUNCTION_LENGTH = 20 // completely rrd made-up number
 
@@ -28,8 +34,11 @@ const checkFunctionSize = (script: SFCScriptBlock, filePath: string) => {
 
 const reportFunctionSize = () => {
   if (functionSizeFiles.length > 0) {
+    // Count only non duplicated objects (by its `filename` property)
+    const fileCount = getUniqueFilenameCount<FunctionSizeFile>(functionSizeFiles, 'filename');
+
     console.log(
-      `\n${TEXT_INFO}rrd${TEXT_RESET} ${BG_WARN}function size${BG_RESET} exceeds recommended limit in ${functionSizeFiles.length} files.`
+      `\n${TEXT_INFO}rrd${TEXT_RESET} ${BG_WARN}function size${BG_RESET} exceeds recommended limit in ${fileCount} files.`
     )
     console.log(`👉 ${TEXT_WARN}Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines${TEXT_RESET}`)
     functionSizeFiles.forEach(file => {

--- a/src/rules/rrd/shortVariableName.ts
+++ b/src/rules/rrd/shortVariableName.ts
@@ -1,5 +1,6 @@
 import { SFCScriptBlock } from "@vue/compiler-sfc";
 import { BG_RESET, BG_WARN, TEXT_WARN, TEXT_RESET, TEXT_INFO } from "../asceeCodes";
+import { getUniqueFilenameCount } from "../../helpers";
 
 type ShortVariableNameFile = {
   filename: string;
@@ -9,12 +10,6 @@ type ShortVariableNameFile = {
 const MIN_VARIABLE_NAME = 4; // completely rrd made-up number
 
 const shortVariableNameFile: ShortVariableNameFile[] = [];
-
-// Helper function to count non duplicated objects
-const getUniqueFilenameCount = (arr: ShortVariableNameFile[]) => {
-  const uniqueFilenames = new Set(arr.map((item) => item.filename));
-  return uniqueFilenames.size;
-};
 
 const checkShortVariableName = (script: SFCScriptBlock, filePath: string) => {
   // Regular expression to match variable names
@@ -33,9 +28,7 @@ const checkShortVariableName = (script: SFCScriptBlock, filePath: string) => {
 const reportShortVariableName = () => {
   if (shortVariableNameFile.length > 0) {
     // Count only non duplicated objects (by its `filename` property)
-    // i.e if three variables have short name from the same file, it will only count as 1 file
-    // and not as 3 files
-    const fileCount = getUniqueFilenameCount(shortVariableNameFile);
+    const fileCount = getUniqueFilenameCount<ShortVariableNameFile>(shortVariableNameFile, "filename");
 
     console.log(
       `\n${TEXT_INFO}rrd${TEXT_RESET} ${BG_WARN}variable names${BG_RESET} are too short in ${fileCount} files.`

--- a/src/rules/vue-strong/templateSimpleExpression.ts
+++ b/src/rules/vue-strong/templateSimpleExpression.ts
@@ -1,8 +1,11 @@
 import { SFCTemplateBlock } from '@vue/compiler-sfc'
 import { BG_RESET, TEXT_WARN, TEXT_RESET, BG_ERR, TEXT_INFO, BG_WARN } from '../asceeCodes'
 import getLineNumber from '../getLineNumber'
+import { getUniqueFilenameCount } from '../../helpers';
 
-const templateSimpleExpressionFiles: { message: string }[] = []
+type TemplateSimpleExpressionFile = { filename: string, message: string };
+
+const templateSimpleExpressionFiles: TemplateSimpleExpressionFile[] = []
 
 const MAX_EXPRESSION_LENGTH = 40 // completely rrd made-up number
 
@@ -14,15 +17,18 @@ const checkTemplateSimpleExpression = (template: SFCTemplateBlock, filePath: str
     if (expression.length > MAX_EXPRESSION_LENGTH) {
       const lineNumber = getLineNumber(template.content, expression)
       const firstPart = expression.split('\n').at(0)?.trim() || ''
-      templateSimpleExpressionFiles.push({ message: `${filePath}#${lineNumber} ${BG_WARN}${firstPart}${BG_RESET}` })
+      templateSimpleExpressionFiles.push({ filename: filePath, message: `${filePath}#${lineNumber} ${BG_WARN}${firstPart}${BG_RESET}` })
     }
   })
 }
 
 const reportTemplateSimpleExpression = () => {
   if (templateSimpleExpressionFiles.length > 0) {
+    // Count only non duplicated objects (by its `filename` property)
+    const fileCount = getUniqueFilenameCount<TemplateSimpleExpressionFile>(templateSimpleExpressionFiles, 'filename')
+
     console.log(
-      `\n${TEXT_INFO}vue-strong${TEXT_RESET} ${BG_ERR}Lengthy template expression${BG_RESET} found in ${templateSimpleExpressionFiles.length} files.`
+      `\n${TEXT_INFO}vue-strong${TEXT_RESET} ${BG_ERR}Lengthy template expression${BG_RESET} found in ${fileCount} files.`
     )
     console.log(
       `👉 ${TEXT_WARN}Refactor the expression into a computed property.${TEXT_RESET} See: https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates`


### PR DESCRIPTION
Before: Indicates rule was offended in two files, but it really is the same file.
![image](https://github.com/user-attachments/assets/9ddbf0f5-0636-4895-bf58-9c631365f8e8)

Before: Indicates rule was offended in 4 files, but it really is the same file.
![image](https://github.com/user-attachments/assets/6ec78f6e-8720-44d1-9a3a-15dd0c143c7b)

After this PR:
![image](https://github.com/user-attachments/assets/8823ec2d-88e6-4a22-8a68-c783740cfef5)
![image](https://github.com/user-attachments/assets/34b95613-14cd-497f-bbc6-810377a1ebfb)

I guess a pending fix would be the plural in `files`... but that can be a commit for later

This might be needed in other rules (I only implemented it in the ones I know for sure need it)
