### PR TITLE
fix: ignore top-level function declarations from antfu/eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,9 @@ import antfu from '@antfu/eslint-config'
 export default antfu({}, {
   rules: {
     // allow console and debugger
-    'no-console': 0,
-    'no-debugger': 0,
+    'no-console': 'off',
+    'no-debugger': 'off',
+    // ignore top-level functions should be declared with function keywordes
+    'antfu/top-level-function': 'off',
   },
 })


### PR DESCRIPTION
related to https://github.com/rrd108/vue-mess-detector/issues/81