### PR TITLE
feat: add suggested readings view in docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -95,6 +95,11 @@ export default defineConfig({
           { text: 'Contribute', link: '/contribute' },
         ],
       },
+      {
+        items: [
+          { text: 'Suggested Readings', link: '/suggested-readings' },
+        ],
+      },
     ],
 
     socialLinks: [{ icon: 'github', link: 'https://github.com/rrd108/vue-mess-detector' }],

--- a/docs/suggested-readings.md
+++ b/docs/suggested-readings.md
@@ -1,0 +1,15 @@
+# 📚 Suggested Readings
+
+This list includes articles on improving code quality in Vue and Nuxt projects, as well as guides on using `vue-mess-detector`. These resources offer valuable insights for enhancing your development practices and understanding the tool.
+
+::: tip
+  Feel free to contribute with suggestions or with your own readings 📑
+:::
+
+## 👥 From the Core Team
+
+### Unlock Cleaner Code in Vue and Nuxt Projects with Vue Mess Detector
+- [Medium](https://medium.com/@rrd108/unlock-cleaner-code-in-vue-and-nuxt-projects-with-vue-mess-detector-34b320d2ab2d) ~ [Dev Community](https://dev.to/rrd/elevate-your-vue-and-nuxt-code-quality-with-vue-mess-detector-4lm3)
+
+### Effortless Refactoring in Vue.js: A Guide to Vue Mess Detector
+- [Medium](https://medium.com/@_davidpena/effortless-refactoring-in-vue-js-a-guide-to-vue-mess-detector-1d64ea3e40cd) ~ [Dev Community](https://dev.to/unans___/effortless-refactoring-in-vuejs-a-guide-to-vue-mess-detector-5756)


### PR DESCRIPTION
### Summary
A "Suggested Readings" view has been added where for now its only showcasing our articles, but the goal is to include more articles related to `vue-mess-detector` itself or specific rules.

### Description
- Added "suggested-readings.md" to vitepress/config
- Added first category "From the Core Team" and showcase two articles

### Related Issues
Fixes #204 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/cfaf5a24-c142-4136-87e4-34c1b96a4e45)