### PR TITLE
feat: add discord perm invite link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ The code health is:
 
 > 👉 For more information, see the [documentation](https://vue-mess-detector.webmania.cc/).
 
+## 👥 Discord Server
+👉 Join our [discord server](https://discord.gg/nXKwzk97jn)
+
 ## 🤝 How to contribute?
 
 See [CONTRIBUTING.md](https://github.com/rrd108/vue-mess-detector/blob/main/CONTRIBUTING.md) file.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -2,6 +2,10 @@
 
 Check your Vue and Nuxt projects for code smells and best practice violations with Vue Mess Detector.
 
+:::tip
+👉 You are welcome to join our [discord server](https://discord.gg/nXKwzk97jn)
+:::
+
 ## 💡What is Static Code Analysis?
 
 Static code analysis is a crucial tool for developers to automatically examine source code **without executing** it, helping identify potential bugs, vulnerabilities, and code quality issues early in the development process. By scanning for problematic patterns, it can catch best practice violations, all code paths, not just those executed during testing. While it has limitations like potential false positives and inability to detect runtime errors, static analysis tools are invaluable for improving code quality, maintainability, and security before the code ever runs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ hero:
       text: Get Started
       link: /get-started
     - theme: alt
+      text: Discord →
+      link: https://discord.gg/nXKwzk97jn
+    - theme: alt
       text: Open on GitHub →
       link: https://github.com/rrd108/vue-mess-detector
 


### PR DESCRIPTION
### Summary
Add discord server to `README.md`, `docs/index.md` and `docs/get-started.md`

### Description
Added perm link invite to above sections

### Related Issues
Fixes #252 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f871d4e8-545b-423d-8b53-d9e7a2a9422a)
![image](https://github.com/user-attachments/assets/5a62ac92-0be5-4fe3-8b6e-5875e32ac935)

