### PR TITLE
feat: enable override option in config object (#276)

### DIFF
--- a/docs/rules/rrd/function-size.md
+++ b/docs/rules/rrd/function-size.md
@@ -1,6 +1,22 @@
 # Function Size
 
-Checks if functions inside `script setup` block are less than 20 lines of code. It handles regular and arrow functions.
+Checks if functions inside `script setup` block are less than **20** lines of code. It handles regular and arrow functions.
+
+:::tip
+  The default max size for this rule is **20**.
+  
+  You can override through the new `override` option in `vue-mess-detector.json`.
+
+  ```json
+  {
+    // Other fields...
+
+    "override": {
+      "maxFunctionSize": 50
+    }
+  }
+  ```
+:::
 
 ## ❓ Why it's good to follow this rule?
 

--- a/docs/rules/rrd/script-length.md
+++ b/docs/rules/rrd/script-length.md
@@ -1,6 +1,22 @@
 # Script Length
 
-Checks if the script section of a Vue component is too long. The default threshold is 100 lines. Between 100 and 200 lines you get a warning, above 200 lines you get an error.
+Checks if the script section of a Vue component is too long. The default threshold is **100** lines. Between 100 and 200 lines you get a warning, above **200** lines you get an error.
+
+:::tip
+  The default max length for this rule is **100** for the warning threshold, and **twice that value** for the error threshold. 
+  
+  You can override through the new `override` option in `vue-mess-detector.json`.
+
+  ```json
+  {
+    // Other fields...
+
+    "override": {
+      "maxScriptLength": 250 // the error threshold would be 2 * 250
+    }
+  }
+  ```
+:::
 
 ## ❓ Why it's good to follow this rule?
 

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-import type { OverwriteConfig } from '../types/Overwrite'
+import type { OverrideConfig } from '../types/Override'
 import { RULES, RULESETS } from '../rules/rules'
 
 export const ERROR_WEIGHT = 1.5
@@ -9,8 +9,8 @@ export const OK_HEALTH_THRESHOLD = 95
 // In case you need to display all allowed rules/rulesets ⬇️
 export const FLAT_RULESETS_RULES = [...RULESETS, ...Object.values(RULES).flat()]
 
-// Overwrite Config ~ Default
-export const DEFAULT_OVERWRITE_CONFIG: OverwriteConfig = {
+// Override Config ~ Default
+export const DEFAULT_OVERRIDE_CONFIG: OverrideConfig = {
   maxFunctionSize: 20,
   maxScriptLength: 100,
 }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,3 +1,4 @@
+import type { OverwriteConfig } from '../types/Overwrite'
 import { RULES, RULESETS } from '../rules/rules'
 
 export const ERROR_WEIGHT = 1.5
@@ -7,3 +8,9 @@ export const OK_HEALTH_THRESHOLD = 95
 
 // In case you need to display all allowed rules/rulesets ⬇️
 export const FLAT_RULESETS_RULES = [...RULESETS, ...Object.values(RULES).flat()]
+
+// Overwrite Config ~ Default
+export const DEFAULT_OVERWRITE_CONFIG: OverwriteConfig = {
+  maxFunctionSize: 20,
+  maxScriptLength: 100,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable node/prefer-global/process */
-import type { GroupBy, OutputFormat, OutputLevel, SortBy } from './types'
+import type { GroupBy, OutputFormat, OutputLevel, SortBy, VueMessDetectorConfig } from './types'
+import type { OverwriteConfig } from './types/Overwrite'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import Table from 'cli-table3'
@@ -7,7 +8,7 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { analyze } from './analyzer'
 import coerceRules from './helpers/coerceRules'
-import { FLAT_RULESETS_RULES } from './helpers/constants'
+import { DEFAULT_OVERWRITE_CONFIG, FLAT_RULESETS_RULES } from './helpers/constants'
 import { getPackageJson } from './helpers/getPackageJson'
 import getProjectRoot from './helpers/getProjectRoot'
 import { validateOption } from './helpers/validateOption'
@@ -18,11 +19,13 @@ import { GROUP_BY, OUTPUT_FORMATS, OUTPUT_LEVELS, SORT_BY } from './types'
 
 const pathArg = process.argv[2] == 'analyze' ? process.argv[3] : process.argv[4]
 
+export const overwriteConfig: OverwriteConfig[] = []
+
 getProjectRoot(pathArg || './src').then((projectRoot) => {
   getPackageJson().then((vmdPackageJson) => {
     const configOutput: { info: string }[] = []
 
-    let config = {
+    let config: VueMessDetectorConfig = {
       path: './src',
       apply: Object.values(RULESETS).join(','),
       ignore: undefined,
@@ -31,6 +34,8 @@ getProjectRoot(pathArg || './src').then((projectRoot) => {
       level: 'all',
       sort: 'desc',
       output: 'text',
+
+      overwrite: DEFAULT_OVERWRITE_CONFIG,
     }
 
     const conflictingFlags: Record<string, boolean> = {
@@ -150,6 +155,8 @@ getProjectRoot(pathArg || './src').then((projectRoot) => {
               console.log(tags2Ascee(message))
               return tags2Ascee(message)
             }
+
+            overwriteConfig.push(config.overwrite)
 
             analyze({
               dir: argv.path as string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable node/prefer-global/process */
 import type { GroupBy, OutputFormat, OutputLevel, SortBy, VueMessDetectorConfig } from './types'
-import type { OverwriteConfig } from './types/Overwrite'
+import type { OverrideConfig } from './types/Override'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import Table from 'cli-table3'
@@ -8,7 +8,7 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { analyze } from './analyzer'
 import coerceRules from './helpers/coerceRules'
-import { DEFAULT_OVERWRITE_CONFIG, FLAT_RULESETS_RULES } from './helpers/constants'
+import { DEFAULT_OVERRIDE_CONFIG, FLAT_RULESETS_RULES } from './helpers/constants'
 import { getPackageJson } from './helpers/getPackageJson'
 import getProjectRoot from './helpers/getProjectRoot'
 import { validateOption } from './helpers/validateOption'
@@ -19,7 +19,7 @@ import { GROUP_BY, OUTPUT_FORMATS, OUTPUT_LEVELS, SORT_BY } from './types'
 
 const pathArg = process.argv[2] == 'analyze' ? process.argv[3] : process.argv[4]
 
-export const overwriteConfig: OverwriteConfig[] = []
+export const overrideConfig: OverrideConfig[] = []
 
 getProjectRoot(pathArg || './src').then((projectRoot) => {
   getPackageJson().then((vmdPackageJson) => {
@@ -35,7 +35,7 @@ getProjectRoot(pathArg || './src').then((projectRoot) => {
       sort: 'desc',
       output: 'text',
 
-      overwrite: DEFAULT_OVERWRITE_CONFIG,
+      override: DEFAULT_OVERRIDE_CONFIG,
     }
 
     const conflictingFlags: Record<string, boolean> = {
@@ -156,7 +156,7 @@ getProjectRoot(pathArg || './src').then((projectRoot) => {
               return tags2Ascee(message)
             }
 
-            overwriteConfig.push(config.overwrite)
+            overrideConfig.push(config.override)
 
             analyze({
               dir: argv.path as string,

--- a/src/rules/rrd/functionSize.test.ts
+++ b/src/rules/rrd/functionSize.test.ts
@@ -1,7 +1,7 @@
 import type { SFCScriptBlock } from '@vue/compiler-sfc'
 
 import { beforeEach, describe, expect, it } from 'vitest'
-import { DEFAULT_OVERWRITE_CONFIG } from '../../helpers/constants'
+import { DEFAULT_OVERRIDE_CONFIG } from '../../helpers/constants'
 import { checkFunctionSize, reportFunctionSize, resetFunctionSize } from './functionSize'
 
 describe('checkFunctionSize', () => {
@@ -26,7 +26,7 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(0)
     expect(reportFunctionSize(maxSize)).toStrictEqual([])
@@ -50,7 +50,7 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(0)
     expect(reportFunctionSize(maxSize)).toStrictEqual([])
@@ -67,7 +67,7 @@ describe('checkFunctionSize', () => {
     `,
     } as SFCScriptBlock
     const fileName = 'multiple-short-functions.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(0)
     expect(reportFunctionSize(maxSize)).toStrictEqual([])
@@ -111,7 +111,7 @@ describe('checkFunctionSize', () => {
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
     const funcName = 'dummyRegularFunction'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(1)
     expect(reportFunctionSize(maxSize)).toStrictEqual([{
@@ -187,7 +187,7 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(2)
     expect(reportFunctionSize(maxSize)).toStrictEqual([{
@@ -252,7 +252,7 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(1)
     expect(reportFunctionSize(maxSize)).toStrictEqual([{
@@ -299,7 +299,7 @@ describe('checkFunctionSize', () => {
         }`,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    const maxSize = DEFAULT_OVERRIDE_CONFIG.maxFunctionSize
     checkFunctionSize(script, fileName, maxSize)
     expect(reportFunctionSize(maxSize).length).toBe(1)
     expect(reportFunctionSize(maxSize)).toStrictEqual([{

--- a/src/rules/rrd/functionSize.test.ts
+++ b/src/rules/rrd/functionSize.test.ts
@@ -1,7 +1,8 @@
 import type { SFCScriptBlock } from '@vue/compiler-sfc'
 
 import { beforeEach, describe, expect, it } from 'vitest'
-import { checkFunctionSize, MAX_FUNCTION_LENGTH, reportFunctionSize, resetFunctionSize } from './functionSize'
+import { DEFAULT_OVERWRITE_CONFIG } from '../../helpers/constants'
+import { checkFunctionSize, reportFunctionSize, resetFunctionSize } from './functionSize'
 
 describe('checkFunctionSize', () => {
   beforeEach(() => {
@@ -25,9 +26,10 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(0)
-    expect(reportFunctionSize()).toStrictEqual([])
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(0)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([])
   })
 
   it('should not report files where arrow functions without curly braces do not exceed the recommended limit', () => {
@@ -48,9 +50,10 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(0)
-    expect(reportFunctionSize()).toStrictEqual([])
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(0)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([])
   })
 
   it('should not report files with multiple short functions', () => {
@@ -64,9 +67,10 @@ describe('checkFunctionSize', () => {
     `,
     } as SFCScriptBlock
     const fileName = 'multiple-short-functions.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(0)
-    expect(reportFunctionSize()).toStrictEqual([])
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(0)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([])
   })
 
   it('should report files with one function exceeding the limit', () => {
@@ -107,12 +111,13 @@ describe('checkFunctionSize', () => {
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
     const funcName = 'dummyRegularFunction'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(1)
-    expect(reportFunctionSize()).toStrictEqual([{
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(1)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([{
       file: fileName,
       rule: `<text_info>rrd ~ function size</text_info>`,
-      description: `👉 <text_warn>Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
+      description: `👉 <text_warn>Functions must be shorter than ${maxSize} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
       message: `function <bg_warn>(${funcName}#2)</bg_warn> is too long: <bg_warn>23 lines</bg_warn> 🚨`,
     }])
   })
@@ -182,17 +187,18 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'function-size.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(2)
-    expect(reportFunctionSize()).toStrictEqual([{
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(2)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([{
       file: fileName,
       rule: `<text_info>rrd ~ function size</text_info>`,
-      description: `👉 <text_warn>Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
+      description: `👉 <text_warn>Functions must be shorter than ${maxSize} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
       message: `function <bg_warn>(dummyRegularFunction#2)</bg_warn> is too long: <bg_warn>29 lines</bg_warn> 🚨`,
     }, {
       file: fileName,
       rule: `<text_info>rrd ~ function size</text_info>`,
-      description: `👉 <text_warn>Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
+      description: `👉 <text_warn>Functions must be shorter than ${maxSize} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
       message: `function <bg_warn>(dummyArrowFunction#34)</bg_warn> is too long: <bg_warn>23 lines</bg_warn> 🚨`,
     }])
   })
@@ -246,12 +252,13 @@ describe('checkFunctionSize', () => {
       `,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(1)
-    expect(reportFunctionSize()).toStrictEqual([{
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(1)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([{
       file: fileName,
       rule: `<text_info>rrd ~ function size</text_info>`,
-      description: `👉 <text_warn>Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
+      description: `👉 <text_warn>Functions must be shorter than ${maxSize} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
       message: `function <bg_err>(getOpenBookings#2)</bg_err> is too long: <bg_err>41 lines</bg_err> 🚨`,
     }])
   })
@@ -292,12 +299,13 @@ describe('checkFunctionSize', () => {
         }`,
     } as SFCScriptBlock
     const fileName = 'arrow-function-size.vue'
-    checkFunctionSize(script, fileName)
-    expect(reportFunctionSize().length).toBe(1)
-    expect(reportFunctionSize()).toStrictEqual([{
+    const maxSize = DEFAULT_OVERWRITE_CONFIG.maxFunctionSize
+    checkFunctionSize(script, fileName, maxSize)
+    expect(reportFunctionSize(maxSize).length).toBe(1)
+    expect(reportFunctionSize(maxSize)).toStrictEqual([{
       file: fileName,
       rule: `<text_info>rrd ~ function size</text_info>`,
-      description: `👉 <text_warn>Functions must be shorter than ${MAX_FUNCTION_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
+      description: `👉 <text_warn>Functions must be shorter than ${maxSize} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/function-size.html`,
       message: `function <bg_warn>(createFiles#10)</bg_warn> is too long: <bg_warn>20 lines</bg_warn> 🚨`,
     }])
   })

--- a/src/rules/rrd/scriptLength.test.ts
+++ b/src/rules/rrd/scriptLength.test.ts
@@ -1,7 +1,8 @@
 import type { SFCScriptBlock } from '@vue/compiler-sfc'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { checkScriptLength, MAX_SCRIPT_LENGTH, reportScriptLength, resetScriptLength } from './scriptLength'
+import { DEFAULT_OVERWRITE_CONFIG } from '../../helpers/constants'
+import { checkScriptLength, reportScriptLength, resetScriptLength } from './scriptLength'
 
 describe('checkScriptLength', () => {
   beforeEach(() => {
@@ -11,9 +12,10 @@ describe('checkScriptLength', () => {
   it('should not report "long scripts" for a short script', () => {
     const shortScript = { content: '<script setup>\nconsole.log("Hello")\n</script>' } as SFCScriptBlock
     const fileName = 'short.vue'
-    checkScriptLength(shortScript, fileName)
-    expect(reportScriptLength().length).toBe(0)
-    expect(reportScriptLength()).toStrictEqual([])
+    const maxLength = DEFAULT_OVERWRITE_CONFIG.maxScriptLength
+    checkScriptLength(shortScript, fileName, maxLength)
+    expect(reportScriptLength(maxLength).length).toBe(0)
+    expect(reportScriptLength(maxLength)).toStrictEqual([])
   })
 
   it('should report long scripts for a long script', () => {
@@ -24,12 +26,13 @@ describe('checkScriptLength', () => {
     content += '\n</script>'
     const longScript = { content } as SFCScriptBlock
     const fileName = 'long.vue'
-    checkScriptLength(longScript, fileName)
-    expect(reportScriptLength().length).toBe(1)
-    expect(reportScriptLength()).toStrictEqual([{
+    const maxLength = DEFAULT_OVERWRITE_CONFIG.maxScriptLength
+    checkScriptLength(longScript, fileName, maxLength)
+    expect(reportScriptLength(maxLength).length).toBe(1)
+    expect(reportScriptLength(maxLength)).toStrictEqual([{
       file: fileName,
       rule: `<text_info>rrd ~ Long <script> blocks</text_info>`,
-      description: `👉 <text_warn>Try to refactor out the logic into composable functions or other files and keep the script block's length under ${MAX_SCRIPT_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/script-length.html`,
+      description: `👉 <text_warn>Try to refactor out the logic into composable functions or other files and keep the script block's length under ${maxLength} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/script-length.html`,
       message: `<bg_warn>(104 lines)</bg_warn> 🚨`,
     }])
   })

--- a/src/rules/rrd/scriptLength.test.ts
+++ b/src/rules/rrd/scriptLength.test.ts
@@ -1,7 +1,7 @@
 import type { SFCScriptBlock } from '@vue/compiler-sfc'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { DEFAULT_OVERWRITE_CONFIG } from '../../helpers/constants'
+import { DEFAULT_OVERRIDE_CONFIG } from '../../helpers/constants'
 import { checkScriptLength, reportScriptLength, resetScriptLength } from './scriptLength'
 
 describe('checkScriptLength', () => {
@@ -12,7 +12,7 @@ describe('checkScriptLength', () => {
   it('should not report "long scripts" for a short script', () => {
     const shortScript = { content: '<script setup>\nconsole.log("Hello")\n</script>' } as SFCScriptBlock
     const fileName = 'short.vue'
-    const maxLength = DEFAULT_OVERWRITE_CONFIG.maxScriptLength
+    const maxLength = DEFAULT_OVERRIDE_CONFIG.maxScriptLength
     checkScriptLength(shortScript, fileName, maxLength)
     expect(reportScriptLength(maxLength).length).toBe(0)
     expect(reportScriptLength(maxLength)).toStrictEqual([])
@@ -26,7 +26,7 @@ describe('checkScriptLength', () => {
     content += '\n</script>'
     const longScript = { content } as SFCScriptBlock
     const fileName = 'long.vue'
-    const maxLength = DEFAULT_OVERWRITE_CONFIG.maxScriptLength
+    const maxLength = DEFAULT_OVERRIDE_CONFIG.maxScriptLength
     checkScriptLength(longScript, fileName, maxLength)
     expect(reportScriptLength(maxLength).length).toBe(1)
     expect(reportScriptLength(maxLength)).toStrictEqual([{

--- a/src/rules/rrd/scriptLength.ts
+++ b/src/rules/rrd/scriptLength.ts
@@ -3,21 +3,19 @@ import type { FileCheckResult, Offense } from '../../types'
 
 const results: FileCheckResult[] = []
 
-export const MAX_SCRIPT_LENGTH = 100
-
-const checkScriptLength = (script: SFCScriptBlock | null, filePath: string) => {
+const checkScriptLength = (script: SFCScriptBlock | null, filePath: string, maxLength: number) => {
   if (!script) {
     return
   }
   const lines = script.content.split('\n')
-  if (lines.length > MAX_SCRIPT_LENGTH) {
-    results.push({ filePath, message: `${lines.length > MAX_SCRIPT_LENGTH * 2 ? '<bg_err>' : '<bg_warn>'}(${
+  if (lines.length > maxLength) {
+    results.push({ filePath, message: `${lines.length > maxLength * 2 ? '<bg_err>' : '<bg_warn>'}(${
       lines.length
-    } lines)${lines.length > MAX_SCRIPT_LENGTH * 2 ? '</bg_err>' : '</bg_warn>'}` })
+    } lines)${lines.length > maxLength * 2 ? '</bg_err>' : '</bg_warn>'}` })
   }
 }
 
-const reportScriptLength = () => {
+const reportScriptLength = (maxLength: number) => {
   const offenses: Offense[] = []
 
   if (results.length > 0) {
@@ -25,7 +23,7 @@ const reportScriptLength = () => {
       offenses.push({
         file: result.filePath,
         rule: `<text_info>rrd ~ Long <script> blocks</text_info>`,
-        description: `👉 <text_warn>Try to refactor out the logic into composable functions or other files and keep the script block's length under ${MAX_SCRIPT_LENGTH} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/script-length.html`,
+        description: `👉 <text_warn>Try to refactor out the logic into composable functions or other files and keep the script block's length under ${maxLength} lines.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/script-length.html`,
         message: `${result.message} 🚨`,
       })
     })

--- a/src/rulesCheck.ts
+++ b/src/rulesCheck.ts
@@ -1,6 +1,7 @@
 import type { SFCDescriptor } from '@vue/compiler-sfc'
+import type { OverwriteConfig } from './types/Overwrite'
+import { overwriteConfig } from '.'
 import { getIsNuxt } from './context'
-
 import { checkApiWithoutMethod, checkBigVif, checkBigVshow, checkComplicatedConditions, checkComputedSideEffects, checkCyclomaticComplexity, checkDeepIndentation, checkElseCondition, checkFunctionSize, checkHtmlImageElements, checkHtmlLink, checkIfWithoutCurlyBraces, checkMagicNumbers, checkNestedTernary, checkNoInlineStyles, checkNoPropDestructure, checkNoVarDeclaration, checkParameterCount, checkPlainScript, checkPropsDrilling, checkScriptLength, checkShortVariableName, checkTooManyProps, checkVForWithIndexKey, checkZeroLengthComparison } from './rules/rrd'
 import { RULES } from './rules/rules'
 import { checkElementSelectorsWithScoped, checkImplicitParentChildCommunication } from './rules/vue-caution'
@@ -13,6 +14,8 @@ export const checkRules = (descriptor: SFCDescriptor, filePath: string, apply: s
 
   // ⚠️ contributors ⚠️ script rules can be used for ts, js and vue files, but template and style rules are only for vue files
   const isVueFile = filePath.endsWith('.vue')
+
+  const { ...limits } = overwriteConfig[0] as OverwriteConfig
 
   // Create an object that maps rule names to their check functions
   const ruleChecks: Record<string, () => void> = {
@@ -52,7 +55,7 @@ export const checkRules = (descriptor: SFCDescriptor, filePath: string, apply: s
     computedSideEffects: () => checkComputedSideEffects(script, filePath),
     deepIndentation: () => checkDeepIndentation(script, filePath),
     elseCondition: () => checkElseCondition(script, filePath),
-    functionSize: () => checkFunctionSize(script, filePath),
+    functionSize: () => checkFunctionSize(script, filePath, limits.maxFunctionSize),
     htmlImageElements: () => getIsNuxt() && checkHtmlImageElements(descriptor.template, filePath),
     htmlLink: () => isVueFile && checkHtmlLink(descriptor.template, filePath),
     ifWithoutCurlyBraces: () => checkIfWithoutCurlyBraces(script, filePath),
@@ -63,7 +66,7 @@ export const checkRules = (descriptor: SFCDescriptor, filePath: string, apply: s
     parameterCount: () => checkParameterCount(script, filePath),
     plainScript: () => isVueFile && checkPlainScript(descriptor.script, filePath),
     propsDrilling: () => checkPropsDrilling(script, filePath),
-    scriptLength: () => checkScriptLength(script, filePath),
+    scriptLength: () => checkScriptLength(script, filePath, limits.maxScriptLength),
     shortVariableName: () => checkShortVariableName(script, filePath),
     tooManyProps: () => checkTooManyProps(script, filePath),
     vForWithIndexKey: () => isVueFile && checkVForWithIndexKey(descriptor.template, filePath),

--- a/src/rulesCheck.ts
+++ b/src/rulesCheck.ts
@@ -1,6 +1,6 @@
 import type { SFCDescriptor } from '@vue/compiler-sfc'
-import type { OverwriteConfig } from './types/Overwrite'
-import { overwriteConfig } from '.'
+import type { OverrideConfig } from './types/Override'
+import { overrideConfig } from '.'
 import { getIsNuxt } from './context'
 import { checkApiWithoutMethod, checkBigVif, checkBigVshow, checkComplicatedConditions, checkComputedSideEffects, checkCyclomaticComplexity, checkDeepIndentation, checkElseCondition, checkFunctionSize, checkHtmlImageElements, checkHtmlLink, checkIfWithoutCurlyBraces, checkMagicNumbers, checkNestedTernary, checkNoInlineStyles, checkNoPropDestructure, checkNoVarDeclaration, checkParameterCount, checkPlainScript, checkPropsDrilling, checkScriptLength, checkShortVariableName, checkTooManyProps, checkVForWithIndexKey, checkZeroLengthComparison } from './rules/rrd'
 import { RULES } from './rules/rules'
@@ -15,7 +15,7 @@ export const checkRules = (descriptor: SFCDescriptor, filePath: string, apply: s
   // ⚠️ contributors ⚠️ script rules can be used for ts, js and vue files, but template and style rules are only for vue files
   const isVueFile = filePath.endsWith('.vue')
 
-  const { ...limits } = overwriteConfig[0] as OverwriteConfig
+  const { ...limits } = overrideConfig[0] as OverrideConfig
 
   // Create an object that maps rule names to their check functions
   const ruleChecks: Record<string, () => void> = {

--- a/src/rulesReport.ts
+++ b/src/rulesReport.ts
@@ -1,7 +1,7 @@
 import type { GroupBy, Health, Offense, OffensesGrouped, OutputLevel, ReportFunction, SortBy } from './types'
 import type { OutputType } from './types/OutputType'
-import type { OverwriteConfig } from './types/Overwrite'
-import { overwriteConfig } from '.'
+import type { OverrideConfig } from './types/Override'
+import { overrideConfig } from '.'
 import { reportApiWithoutMethod, reportBigVif, reportBigVshow, reportComplicatedConditions, reportComputedSideEffects, reportCyclomaticComplexity, reportDeepIndentation, reportElseCondition, reportFunctionSize, reportHtmlImageElements, reportHtmlLink, reportIfWithoutCurlyBraces, reportMagicNumbers, reportNestedTernary, reportNoInlineStyles, reportNoPropDestructure, reportNoVarDeclaration, reportParameterCount, reportPlainScript, reportPropsDrilling, reportScriptLength, reportShortVariableName, reportTooManyProps, reportVForWithIndexKey, reportZeroLengthComparison } from './rules/rrd'
 import { reportElementSelectorsWithScoped, reportImplicitParentChildCommunication } from './rules/vue-caution'
 import { reportGlobalStyle, reportSimpleProp, reportSingleNameComponent, reportVforNoKey, reportVifWithVfor } from './rules/vue-essential'
@@ -13,7 +13,7 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   const output: OutputType = {}
   const health: Health[] = []
 
-  const { ...limits } = overwriteConfig[0] as OverwriteConfig
+  const { ...limits } = overrideConfig[0] as OverrideConfig
 
   // Helper function to add offenses
   const addOffense = ({ file, rule, title, description, message }: Offense) => {

--- a/src/rulesReport.ts
+++ b/src/rulesReport.ts
@@ -1,5 +1,7 @@
 import type { GroupBy, Health, Offense, OffensesGrouped, OutputLevel, ReportFunction, SortBy } from './types'
 import type { OutputType } from './types/OutputType'
+import type { OverwriteConfig } from './types/Overwrite'
+import { overwriteConfig } from '.'
 import { reportApiWithoutMethod, reportBigVif, reportBigVshow, reportComplicatedConditions, reportComputedSideEffects, reportCyclomaticComplexity, reportDeepIndentation, reportElseCondition, reportFunctionSize, reportHtmlImageElements, reportHtmlLink, reportIfWithoutCurlyBraces, reportMagicNumbers, reportNestedTernary, reportNoInlineStyles, reportNoPropDestructure, reportNoVarDeclaration, reportParameterCount, reportPlainScript, reportPropsDrilling, reportScriptLength, reportShortVariableName, reportTooManyProps, reportVForWithIndexKey, reportZeroLengthComparison } from './rules/rrd'
 import { reportElementSelectorsWithScoped, reportImplicitParentChildCommunication } from './rules/vue-caution'
 import { reportGlobalStyle, reportSimpleProp, reportSingleNameComponent, reportVforNoKey, reportVifWithVfor } from './rules/vue-essential'
@@ -10,6 +12,8 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   const offensesGrouped: OffensesGrouped = {}
   const output: OutputType = {}
   const health: Health[] = []
+
+  const { ...limits } = overwriteConfig[0] as OverwriteConfig
 
   // Helper function to add offenses
   const addOffense = ({ file, rule, title, description, message }: Offense) => {
@@ -65,7 +69,7 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   processOffenses(reportComputedSideEffects)
   processOffenses(reportDeepIndentation)
   processOffenses(reportElseCondition)
-  processOffenses(reportFunctionSize)
+  processOffenses(() => reportFunctionSize(limits.maxFunctionSize))
   processOffenses(reportHtmlImageElements)
   processOffenses(reportHtmlLink)
   processOffenses(reportIfWithoutCurlyBraces)
@@ -76,7 +80,7 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   processOffenses(reportParameterCount)
   processOffenses(reportPlainScript)
   processOffenses(reportPropsDrilling)
-  processOffenses(reportScriptLength)
+  processOffenses(() => reportScriptLength(limits.maxScriptLength))
   processOffenses(reportShortVariableName)
   processOffenses(reportTooManyProps)
   processOffenses(reportVForWithIndexKey)

--- a/src/types/Override.ts
+++ b/src/types/Override.ts
@@ -3,6 +3,6 @@ const OVERWRITABLE_RULES = ['functionSize', 'scriptLength'] as const
 
 type RuleConfig = number
 
-export interface OverwriteConfig {
+export interface OverrideConfig {
   [key: string]: RuleConfig
 }

--- a/src/types/Overwrite.ts
+++ b/src/types/Overwrite.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line unused-imports/no-unused-vars
+const OVERWRITABLE_RULES = ['functionSize', 'scriptLength'] as const
+
+type RuleConfig = number
+
+export interface OverwriteConfig {
+  [key: string]: RuleConfig
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { OverwriteConfig } from './Overwrite'
+
 export type Flag = 'groupBy' | 'sortBy' | 'outputLevel' | 'outputFormat'
 /*
   - `asc` is the default order, as the checks run.
@@ -56,3 +58,16 @@ export interface Health {
 }
 
 export type CodeHealthResponse = Omit<Health, 'file'>
+
+// Overall configuration type
+export interface VueMessDetectorConfig {
+  path: string
+  apply: string
+  ignore?: string
+  exclude?: string
+  group: string
+  level: string
+  sort: string
+  output: string
+  overwrite: OverwriteConfig
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { OverwriteConfig } from './Overwrite'
+import type { OverrideConfig } from './Override'
 
 export type Flag = 'groupBy' | 'sortBy' | 'outputLevel' | 'outputFormat'
 /*
@@ -69,5 +69,5 @@ export interface VueMessDetectorConfig {
   level: string
   sort: string
   output: string
-  overwrite: OverwriteConfig
+  override: OverrideConfig
 }


### PR DESCRIPTION
### Summary
Enable `override` field in `vue-mess-detector.json` to overwrite the max value for `functionSize` and `scriptLength`.

### Proposal
The feedback received in our discord server from @jonathan-terrell  about some "hardcoded" limits in our rules helped me align what do I think its one of the best usage for this tool. It's okay to be a bit opinionated but to provide a way for you to setup some of those opinions its a powerful feature for team work.

In my day-to-day job I manage at least two small teams where this `overwrite` was what it was missing for it to couple perfectly into our workflows.

I think this feature will attract more users 👀

### Description
- Create `overrideConfig` constant to share between files.
- Add types for `vue-mess-detector.json` file
- Update `functionSize` and `scriptLength` to use this constant
- Create `DEFAULT_OVERRIDE_CONFIG` and include `maxFunctionSize` and `maxScriptLength` fields
- Update docs to showcase this feature 

### Related Issues
Fixes #276 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

### Screenshots (if applicable)
With this `vue-mess-detector.json` 
```json
{
    "apply": "functionSize,scriptLength",
    "group": "file",
}
```
![image](https://github.com/user-attachments/assets/e86b8d09-88f2-43e7-bab3-25e633d9d32b)
![image](https://github.com/user-attachments/assets/7a2add0b-532b-4f8c-9342-55f1e3d8ff00)

Now we include our override options:
```json
{
    "apply": "functionSize,scriptLength",
    "group": "file",
    "override": {
        "maxFunctionSize": 50
    }
}
```
![image](https://github.com/user-attachments/assets/e35136f7-cd4e-4b34-aaa1-a14487852c08)
![image](https://github.com/user-attachments/assets/57f939b8-b851-47c6-babe-c950f2248b70)

```json
{
    "apply": "functionSize,scriptLength",
    "group": "file",
    "override": {
        "maxFunctionSize": 50,
        "maxScriptLength": 250
    }
}
```
With this increase, we have no reports for `scriptLength` rule
![image](https://github.com/user-attachments/assets/3ccbebbc-d6ab-428f-a52e-2d7439ce364d)

Updated docs ⬇️
![image](https://github.com/user-attachments/assets/78f5725b-d0ec-48bf-97fb-399a9981e9e4)
![image](https://github.com/user-attachments/assets/d1a2ba01-d377-4500-b8b8-55cff5ec8158)

