### PR TITLE
fix: now name rules skip `index.vue`

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -19,6 +19,9 @@ export const DOM_METHODS = [
   'querySelectorAll',
 ]
 
+// Name rules
+export const IGNORE_NAME_RULES = ['index.vue', 'app.vue']
+
 // Override Config ~ Default
 export const DEFAULT_OVERRIDE_CONFIG: OverrideConfig = {
   maxExpressionLength: 40,

--- a/src/rules/vue-essential/singleNameComponent.test.ts
+++ b/src/rules/vue-essential/singleNameComponent.test.ts
@@ -23,7 +23,7 @@ describe('checkSingleNameComponent', () => {
     expect(result).toStrictEqual([])
   })
 
-  it.todo('ignores index.vue', () => {
+  it('ignores index.vue', () => {
     checkSingleNameComponent('components/users/index.vue')
     const result = reportSingleNameComponent()
     expect(result.length).toBe(0)

--- a/src/rules/vue-essential/singleNameComponent.ts
+++ b/src/rules/vue-essential/singleNameComponent.ts
@@ -1,7 +1,7 @@
 import type { FileCheckResult, Offense } from '../../types'
 import path from 'node:path'
-
 import { createRegExp, letter } from 'magic-regexp'
+import { IGNORE_NAME_RULES } from '../../helpers/constants'
 
 const results: FileCheckResult[] = []
 
@@ -14,7 +14,7 @@ const checkSingleNameComponent = (filePath: string) => {
   }
 
   const fileName = path.basename(filePath)
-  if (fileName.toLowerCase() === 'app.vue') {
+  if (IGNORE_NAME_RULES.includes(fileName.toLowerCase())) {
     return
   }
 

--- a/src/rules/vue-strong/componentFilenameCasing.test.ts
+++ b/src/rules/vue-strong/componentFilenameCasing.test.ts
@@ -40,7 +40,7 @@ describe('checkComponentFilenameCasing', () => {
     expect(result).toStrictEqual([])
   })
 
-  it.todo('ignores index.vue files', () => {
+  it('ignores index.vue files', () => {
     checkComponentFilenameCasing('src/index.vue')
     const result = reportComponentFilenameCasing()
     expect(result.length).toBe(0)

--- a/src/rules/vue-strong/componentFilenameCasing.ts
+++ b/src/rules/vue-strong/componentFilenameCasing.ts
@@ -1,6 +1,6 @@
 import type { FileCheckResult, Offense } from '../../types'
-
 import path from 'node:path'
+import { IGNORE_NAME_RULES } from '../../helpers/constants'
 
 const results: FileCheckResult[] = []
 
@@ -13,7 +13,7 @@ const checkComponentFilenameCasing = (filePath: string) => {
 
   const fileName = path.basename(filePath)
 
-  if (fileName.toLowerCase() === 'app.vue') {
+  if (IGNORE_NAME_RULES.includes(fileName.toLowerCase())) {
     return
   }
 

--- a/src/rules/vue-strong/fullWordComponentName.test.ts
+++ b/src/rules/vue-strong/fullWordComponentName.test.ts
@@ -21,9 +21,9 @@ describe('fullWordComponentName', () => {
     expect(result).toStrictEqual([])
   })
 
-  it.todo('should not report files where filename is index.vue', () => {
+  it('should not report files where filename is index.vue', () => {
     const filename = 'src/index.vue'
-    const minimumConsonantCount = DEFAULT_OVERRIDE_CONFIG.minimumConsonantCount // It only passes because the default minimumConsonantCount is 3
+    const minimumConsonantCount = DEFAULT_OVERRIDE_CONFIG.minimumConsonantCount
     checkFullWordComponentName(filename, minimumConsonantCount)
     const result = reportFullWordComponentName()
     expect(result.length).toBe(0)

--- a/src/rules/vue-strong/fullWordComponentName.ts
+++ b/src/rules/vue-strong/fullWordComponentName.ts
@@ -1,41 +1,31 @@
 import type { FileCheckResult, Offense } from '../../types'
-
-import { charIn, charNotIn, createRegExp, exactly, global, oneOrMore } from 'magic-regexp'
+import path from 'node:path'
+import { charIn, createRegExp, global } from 'magic-regexp'
+import { IGNORE_NAME_RULES } from '../../helpers/constants'
 
 const results: FileCheckResult[] = []
 
 const resetResults = () => (results.length = 0)
 
 const checkFullWordComponentName = (filePath: string, minimumConsonantCount: number) => {
-  // regular expression to match `filename.vue` pattern
-  const regex = createRegExp(
-    oneOrMore(charNotIn('/')).grouped(),
-    exactly('.vue').at.lineEnd(),
+  const fileName = path.basename(filePath)
+
+  if (IGNORE_NAME_RULES.includes(fileName.toLowerCase())) {
+    return
+  }
+
+  const splittedFileName = fileName?.split('.vue')[0] as string
+
+  // regular expression to match and count consonants
+  const consonantsRegex = createRegExp(
+    charIn('bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ'),
+    [global],
   )
 
-  const match = filePath.match(regex)
+  const consonantsMatch = splittedFileName.match(consonantsRegex)
 
-  if (match) {
-    const matchedFilename = match[0]
-
-    // ignores default Vue/Nuxt app file
-    if (matchedFilename?.toLowerCase() === 'app.vue') {
-      return
-    }
-
-    const filename = matchedFilename?.split('.vue')[0] as string
-
-    // regular expression to match and count consonants
-    const consonantsRegex = createRegExp(
-      charIn('bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ'),
-      [global],
-    )
-
-    const consonantsMatch = filename.match(consonantsRegex)
-
-    if (!consonantsMatch || consonantsMatch.length < minimumConsonantCount) {
-      results.push({ filePath, message: `${filename} is not a <bg_warn>full word.</bg_warn>` })
-    }
+  if (!consonantsMatch || consonantsMatch.length < minimumConsonantCount) {
+    results.push({ filePath, message: `${splittedFileName} is not a <bg_warn>full word.</bg_warn>` })
   }
 }
 


### PR DESCRIPTION
### Summary
Now all name rules skip `index.vue` and won't report it

### Description
- Created constant for names we should ignore (app and index for now)
- Update condition in `singleNameComponent` rule
- Update condition in `componentFilenameCasing` rule
- Update condition in `fullWordComponentName` rule

### Related Issues
Fixes #335 

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
