### PR TITLE
fix : ignore layouts directory

### DIFF
--- a/src/rules/vue-essential/singleNameComponent.test.ts
+++ b/src/rules/vue-essential/singleNameComponent.test.ts
@@ -9,6 +9,13 @@ describe('checkSingleNameComponent', () => {
     expect(result).toStrictEqual([])
   })
 
+  it('ignores layouts directory', () => {
+    checkSingleNameComponent('layouts/default.vue')
+    const result = reportSingleNameComponent()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
   it('ignores App.vue', () => {
     checkSingleNameComponent('components/App.vue')
     const result = reportSingleNameComponent()

--- a/src/rules/vue-essential/singleNameComponent.ts
+++ b/src/rules/vue-essential/singleNameComponent.ts
@@ -1,6 +1,6 @@
-import type { FileCheckResult, Offense } from '../../types'
 import path from 'node:path'
 import { createRegExp, letter } from 'magic-regexp'
+import type { FileCheckResult, Offense } from '../../types'
 import { IGNORE_NAME_RULES } from '../../helpers/constants'
 
 const results: FileCheckResult[] = []
@@ -8,8 +8,8 @@ const results: FileCheckResult[] = []
 const resetResults = () => (results.length = 0)
 
 const checkSingleNameComponent = (filePath: string) => {
-  // in the pages directory this rule does not apply
-  if (filePath.includes('pages')) {
+  // in the pages and layouts directory this rule does not apply
+  if (filePath.includes('pages') || filePath.includes('layouts')) {
     return
   }
 

--- a/src/rules/vue-essential/singleNameComponent.ts
+++ b/src/rules/vue-essential/singleNameComponent.ts
@@ -1,6 +1,6 @@
+import type { FileCheckResult, Offense } from '../../types'
 import path from 'node:path'
 import { createRegExp, letter } from 'magic-regexp'
-import type { FileCheckResult, Offense } from '../../types'
 import { IGNORE_NAME_RULES } from '../../helpers/constants'
 
 const results: FileCheckResult[] = []


### PR DESCRIPTION
### Summary
<!-- Provide a general summary of your changes in the title above -->
Fix for the rule  "Rename the component to use multi-word name"

### Description
<!-- Describe your changes in detail -->
I skipped the layout directory so as not to analyze it for the rule

### Related Issues
<!-- List any related issues or pull requests, using the format `Fixes #issue_number` -->
Fixes #345

### Type of Change
<!-- Please select the options that best describe your changes -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Screenshots (if applicable)
<!-- Add screenshots to help expalin the changes -->
