### PR TITLE
fix: add new regex to handle nested self-closing (#391)

### DIFF
--- a/src/rules/vue-strong/selfClosingComponents.test.ts
+++ b/src/rules/vue-strong/selfClosingComponents.test.ts
@@ -20,6 +20,25 @@ describe('checkSelfClosingComponents', () => {
     expect(result).toStrictEqual([])
   })
 
+  it('should not report files with self-closing components', () => {
+    const template = `<template>
+      <a
+        href="/path/to/link"
+      ><InsideComponent /></a>
+    </template>`
+    const descriptor = {
+      source: template,
+      template: {
+        content: template,
+      },
+    } as SFCDescriptor
+    const fileName = 'self-close-component.vue'
+    checkSelfClosingComponents(descriptor, fileName)
+    const result = reportSelfClosingComponents()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
   it('should not report files where the components self close', () => {
     const template = `<template>
       <MyComponent />


### PR DESCRIPTION
### Summary
Fix false positive for `selfClosingComponents` rule because of the self-closing component within nested html

### Description
- Added new regex to match valid self-closing components

This change should allowthe function to handle cases wherea self-closing component is nested inside another HTML tag

### Related Issues
Fixes #391 

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if applicable)
N/A