### PR TITLE
fix: `--version` now prints the dependency version instead of the project's package.json `version` field

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { getConfig } from './helpers/getConfig'
 import { getEscapedLink } from './helpers/getEscapedLink'
 import { getPackageJson } from './helpers/getPackageJson'
 import getProjectRoot from './helpers/getProjectRoot'
+import { getVersion } from './helpers/getVersion'
 import { validateOption } from './helpers/validateOption'
 import { BG_ERR, BG_RESET, tags2Ascee } from './rules/asceeCodes'
 import { GROUP_BY, OUTPUT_FORMATS, OUTPUT_LEVELS, SORT_BY } from './types'
@@ -211,7 +212,7 @@ getProjectRoot(pathArg).then(async (projectRoot) => {
           })
         },
       })
-      .version('version', 'Show version number', vmdPackageJson.version)
+      .version('version', 'Show version number', getVersion(vmdPackageJson))
       .alias('version', 'v')
       .help()
 

--- a/src/helpers/getVersion.ts
+++ b/src/helpers/getVersion.ts
@@ -1,0 +1,8 @@
+import type { PackageJson } from '../types/PackageJson'
+
+export function getVersion(vmdPackageJson: PackageJson) {
+  const vmdName = 'vue-mess-detector'
+  return vmdPackageJson?.devDependencies?.[vmdName]
+    || vmdPackageJson?.dependencies?.[vmdName]
+    || 'VMD is not installed in your project'
+}

--- a/src/types/PackageJson.ts
+++ b/src/types/PackageJson.ts
@@ -1,12 +1,14 @@
 export interface PackageJson {
   version: string
   dependencies?: {
-    vue?: string
-    nuxt?: string
+    'vue'?: string
+    'nuxt'?: string
+    'vue-mess-detector'?: string
   }
   devDependencies?: {
-    vue?: string
-    nuxt?: string
+    'vue'?: string
+    'nuxt'?: string
+    'vue-mess-detector'?: string
   }
   peerDependencies?: {
     vue?: string


### PR DESCRIPTION
### Summary
Add helper method to retrieve correctly dependency version for `--version` flag

### Description
- Add `getVersion` helper 
- Update `VMD` interface

### Related Issues
Fixes #428 

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if applicable)
N/A