### PR TITLE
Fix JSR Publish and Documentation Release

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '20'
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -12,5 +12,9 @@ jobs:
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: yarn
       - run: yarn install
       - run: npx jsr publish --allow-dirty


### PR DESCRIPTION
### Summary
<!-- Provide a general summary of your changes in the title above -->
_Should_ fix ci by setting ci to use node 20 instead.

### Description
<!-- Describe your changes in detail -->

Sets the version of node used in github actions to 20.

### Related Issues
<!-- List any related issues or pull requests, using the format `Fixes #issue_number` -->
Fixes #463 

### Type of Change
<!-- Please select the options that best describe your changes -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
    - Not part of this, but this implicitly suggest that this library won't install with node 18 anymore (outside of using `ignore-engines). This is more of a question of if we should support the minimum versions that align with the minimum versions of vue/nuxt or if we want to help everyone bump up. (The latter is a good way to do it, but tooling working on a huge range of different underlying versions does make their adoption easier, albeit adds a lot of headaches making sure it runs well with a large range of runtime environments.)
- [ ] Documentation update

(Not a github actions wizard so there might be a way to run this in some pre-deployment tooling to verify this works, I think it should but only when executing it can I be sure.)
