### PR TITLE
fix: hide rule groups with no offenses in output

### DIFF
--- a/src/rulesReport.test.ts
+++ b/src/rulesReport.test.ts
@@ -1,0 +1,48 @@
+import type { SFCScriptBlock } from '@vue/compiler-sfc'
+import { describe, expect, it } from 'vitest'
+import { checkComputedSideEffects } from './rules/rrd/computedSideEffects'
+import { checkMagicNumbers } from './rules/rrd/magicNumbers'
+import { reportRules } from './rulesReport'
+
+// The rule key in the output includes <text_info> tags from the offense.rule field
+const MAGIC_NUMBERS_KEY = '<text_info>rrd ~ magic numbers</text_info>'
+const COMPUTED_SIDE_EFFECTS_KEY = '<text_info>rrd ~ computed side effects</text_info>'
+
+describe('reportRules — empty groups not displayed (issue #346)', () => {
+  it('should include groups that have offenses in the output', () => {
+    // magicNumbers produces <bg_warn> messages (warnings)
+    const script = { content: 'if (ms < 100) { }' } as SFCScriptBlock
+    const fileName = 'test-with-warning.vue'
+    checkMagicNumbers(script, fileName)
+
+    const { output } = reportRules('rule', 'desc', 'all', {} as any)
+
+    // magic numbers group should be present
+    expect(output[MAGIC_NUMBERS_KEY]).toBeDefined()
+    expect(output[MAGIC_NUMBERS_KEY].length).toBeGreaterThan(0)
+  })
+
+  it('should not output empty groups when level=error filters out all warnings', () => {
+    // magicNumbers produces <bg_warn> messages (warnings), not <bg_err>
+    const script = { content: 'if (ms < 100) { }' } as SFCScriptBlock
+    const fileName = 'test-warning-only.vue'
+    checkMagicNumbers(script, fileName)
+
+    // level=error filters out warnings, so the group should NOT appear
+    const { output } = reportRules('rule', 'desc', 'error', {} as any)
+
+    expect(output[MAGIC_NUMBERS_KEY]).toBeUndefined()
+  })
+
+  it('should include error-level groups even when level=error', () => {
+    // computedSideEffects produces <bg_err> messages (errors)
+    const script = { content: 'const c = computed(() => { let total = 0; total = 1; return total })' } as SFCScriptBlock
+    const fileName = 'test-with-error.vue'
+    checkComputedSideEffects(script, fileName)
+
+    const { output } = reportRules('rule', 'desc', 'error', {} as any)
+
+    expect(output[COMPUTED_SIDE_EFFECTS_KEY]).toBeDefined()
+    expect(output[COMPUTED_SIDE_EFFECTS_KEY].length).toBeGreaterThan(0)
+  })
+})

--- a/src/rulesReport.ts
+++ b/src/rulesReport.ts
@@ -109,8 +109,9 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   })
 
   sortedKeys.forEach((key) => {
-    output[key] = []
-    offensesGrouped[key].forEach((offense, i) => {
+    const groupItems: { id: string, description: string, message: string, level: string }[] = []
+
+    offensesGrouped[key].forEach((offense) => {
       const isError = offense.message.includes('<bg_err>')
       // if health already has the file, push the error
       if (health.some(h => h.file === offense.file)) {
@@ -130,18 +131,24 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
         return
       }
 
-      output[key][i] = { id: '', description: '', message: '', level: isError ? 'error' : 'warning' }
+      const item = { id: '', description: '', message: '', level: isError ? 'error' : 'warning' }
 
       if (groupBy === 'file') {
-        output[key][i].id = offense.rule
+        item.id = offense.rule
       }
 
       if (groupBy !== 'file') {
-        output[key][i].id = offense.file
+        item.id = offense.file
       }
-      output[key][i].description = offense.description
-      output[key][i].message = offense.message || '🚨'
+      item.description = offense.description
+      item.message = offense.message || '🚨'
+      groupItems.push(item)
     })
+
+    // Only add the group to the output if it has at least one visible offense
+    if (groupItems.length > 0) {
+      output[key] = groupItems
+    }
   })
 
   return { output, health }


### PR DESCRIPTION
## Description

Closes #346

When running with `--level=error`, rule groups that only contain warning-level offenses were still displayed in the output with empty content (headers but no offenses underneath). This was confusing — it looked like the tool found issues but had nothing to report.

## Root Cause

In `rulesReport.ts`, the `output[key] = []` was created for every group before processing offenses. When `level === error` filtered out all warnings in a group, the empty array remained in the output object, causing the CLI to print group headers with no content.

## Fix

- Build group items into a local array first, only adding the group to `output` if it has at least one visible offense
- This also fixes a secondary bug: sparse arrays were created because `output[key][i]` used the forEach index but some entries were skipped by the `level === error` early return

## Testing

- Added `src/rulesReport.test.ts` with 3 tests covering:
  - Groups with offenses appear in output (level=all)
  - Groups with only warnings do NOT appear when level=error
  - Groups with errors DO appear when level=error
- All 265 existing tests still pass
- Lint passes clean