### PR TITLE
fix: detect deeply nested computed properties in simpleComputed

### DIFF
--- a/src/rules/vue-strong/simpleComputed.test.ts
+++ b/src/rules/vue-strong/simpleComputed.test.ts
@@ -96,4 +96,32 @@ describe('checkSimpleComputed', () => {
       message: `line #2 <bg_warn>computed</bg_warn> 🚨`,
     }])
   })
+
+  it('should report files with deeply nested computed properties (#358)', () => {
+    const script = {
+      content: `<script setup>
+      const foo = computed(() => {
+        if (bar) {
+          if (baz) {
+            if (qux) {
+              return 1
+            }
+          }
+        }
+        return 0
+      })
+    </script>`,
+    } as SFCScriptBlock
+    const fileName = 'nested-computed.vue'
+    const maxComputedLength = DEFAULT_OVERRIDE_CONFIG.maxComputedLength
+    checkSimpleComputed(script, fileName, maxComputedLength)
+    const result = reportSimpleComputed()
+    expect(result.length).toBe(1)
+    expect(result).toStrictEqual([{
+      file: fileName,
+      rule: `<text_info>vue-strong ~ complicated computed property</text_info>`,
+      description: `👉 <text_warn>Refactor the computed properties to smaller ones.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/vue-strong/simple-computed.html`,
+      message: `line #2 <bg_warn>computed</bg_warn> 🚨`,
+    }])
+  })
 })

--- a/src/rules/vue-strong/simpleComputed.ts
+++ b/src/rules/vue-strong/simpleComputed.ts
@@ -13,23 +13,44 @@ const checkSimpleComputed = (script: SFCScriptBlock | null, filePath: string, ma
     return
   }
 
-  // eslint-disable-next-line regexp/prefer-w, regexp/strict, regexp/no-useless-flag
-  const regex = /const\s+([a-zA-Z0-9_$]+)\s*=\s*computed\(\s*\(\)\s*=>\s*{([^{}]*(?:{[^{}]*}[^{}]*)*)}\s*\)/gs
+  // Match only the opening of a block-body computed; the body is captured by
+  // balanced brace counting below so arbitrarily deep nesting is detected.
+  // eslint-disable-next-line regexp/prefer-w
+  const startRegex = /const\s+[a-zA-Z0-9_$]+\s*=\s*computed\(\s*\(\)\s*=>\s*\{/g
 
   const content = skipComments(script.content)
-  const matches = content.match(regex)
-  if (matches?.length) {
-    matches.forEach((match) => {
-      if (match.split('\n').length > maxComputedLength) {
-        const firstLine = match.split('\n')[0]
-        const lineNumber = getLineNumber(script.content, firstLine)
-        results.push({ filePath, message: `line #${lineNumber} <bg_warn>computed</bg_warn>` })
-        complicatedComputedFiles.push({ filePath })
-        if (!complicatedComputedFiles.some(file => file.filePath === filePath)) {
-          complicatedComputedFiles.push({ filePath })
-        }
+
+  let startMatch: RegExpExecArray | null = startRegex.exec(content)
+  while (startMatch !== null) {
+    // startRegex.lastIndex points at the character right after the opening '{'.
+    let braceCount = 1
+    let currentIndex = startRegex.lastIndex
+
+    while (braceCount > 0 && currentIndex < content.length) {
+      if (content[currentIndex] === '{') {
+        braceCount++
       }
-    })
+      else if (content[currentIndex] === '}') {
+        braceCount--
+      }
+      currentIndex++
+    }
+
+    const block = content.slice(startMatch.index, currentIndex)
+
+    if (block.split('\n').length > maxComputedLength) {
+      const firstLine = block.split('\n')[0]
+      const lineNumber = getLineNumber(script.content, firstLine)
+      results.push({ filePath, message: `line #${lineNumber} <bg_warn>computed</bg_warn>` })
+      complicatedComputedFiles.push({ filePath })
+      if (!complicatedComputedFiles.some(file => file.filePath === filePath)) {
+        complicatedComputedFiles.push({ filePath })
+      }
+    }
+
+    // Resume scanning after the consumed computed block.
+    startRegex.lastIndex = currentIndex
+    startMatch = startRegex.exec(content)
   }
 }
 


### PR DESCRIPTION
### Summary

Fix `simpleComputed` so it detects deeply nested computed properties instead of silently skipping them.

### Description

`checkSimpleComputed` in `src/rules/vue-strong/simpleComputed.ts` matched the body of a block computed with a single regex whose sub-pattern (`{([^{}]*(?:{[^{}]*}[^{}]*)*)}`) can only span braces nested one level deep. Any computed with two or more levels of nesting failed to match, so the whole `computed(...)` was silently skipped and never reported - a false negative that gets more likely the more deeply nested (and complicated) the computed is.

This replaces the body regex with a start-only regex plus balanced brace counting: from the opening `{` of the computed body it scans forward, incrementing/decrementing a `braceCount` until it returns to zero, yielding the full block regardless of nesting depth. The reporting logic, offense message, and line-number derivation are unchanged, and scanning resumes past each consumed block so multiple computeds per file are still handled.

This is the approach the maintainer endorsed in the issue thread: rather than the AST/parser rewrite the reporter suggested (tracked separately by #368), David-Pena proposed reusing the open/close bracket counting "we have in some rules already like the `functionSize`", which @rrd108 confirmed ("Yes. That was the one."). The implementation mirrors `parseArrowFunction` in `src/rules/rrd/functionSize.ts`.

A regression test covers a three-level nested computed that exceeds `maxComputedLength` and asserts exactly one offense; it fails without the fix. The three existing `simpleComputed.test.ts` cases pass unchanged, no new dependencies.

Verification: `yarn test` (vitest) passes the full suite (278 tests / 61 files), the new #358 regression test passes with the fix and fails without it, and eslint is clean on the changed files.

### Related Issues

Fixes #358

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Screenshots (if applicable)

N/A - logic-only change, covered by the added regression test.
