### PR TITLE
feat: add Strict-Transport-Security (HSTS) security rule

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
               { text: 'Security', link: '/rules/security', collapsed: true, items: [
                 { text: 'API Without Method', link: '/rules/security/api-without-method' },
                 { text: 'Rate Limiter', link: '/rules/security/rate-limiter' },
+                { text: 'Strict Transport Security', link: '/rules/security/strict-transport-security' },
               ] },
             ],
           },

--- a/docs/rules/security/index.md
+++ b/docs/rules/security/index.md
@@ -4,6 +4,7 @@ A set of rules focused on ensuring the security and integrity of your project, c
 
 - [API Without HTTP Method](./api-without-method.md)
 - [Rate Limiter](./rate-limiter.md)
+- [Strict Transport Security](./strict-transport-security.md)
 
 ## ❓ Why it's good to follow this ruleset?
 

--- a/docs/rules/security/strict-transport-security.md
+++ b/docs/rules/security/strict-transport-security.md
@@ -1,0 +1,44 @@
+# Strict Transport Security (HSTS)
+
+Checks if your `nuxt.config` file has the Strict-Transport-Security (HSTS) header configured. The rule scans for `Strict-Transport-Security`, `strict-transport-security`, and `strictTransportSecurity` patterns in your Nuxt config.
+
+## ❓ Why it's good to follow this rule?
+
+The HSTS header ensures that browsers always connect to your site over HTTPS, protecting against downgrade attacks and cookie hijacking. Without HSTS, a man-in-the-middle attacker could intercept the first request and force a connection over HTTP, even if your site supports HTTPS.
+
+When a browser receives the HSTS header, it remembers to only use HTTPS for your site for the specified `max-age` period, and optionally for all subdomains if `includeSubDomains` is set.
+
+## 🤍 How to fix it?
+
+Add the Strict-Transport-Security header to your Nuxt config, either manually or by using [nuxt-security](https://nuxt-security.vercel.app/).
+
+### Option 1: Manual configuration
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  nitro: {
+    routeRules: {
+      '/**': {
+        headers: {
+          'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+        },
+      },
+    },
+  },
+})
+```
+
+### Option 2: Using nuxt-security
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['nuxt-security'],
+  security: {
+    headers: {
+      strictTransportSecurity: 'max-age=31536000; includeSubDomains',
+    },
+  },
+})
+```

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -65,6 +65,7 @@ export const RULES = {
   'security': [
     'apiWithoutMethod',
     'rateLimiter',
+    'strictTransportSecurity',
   ],
 }
 

--- a/src/rules/security/index.ts
+++ b/src/rules/security/index.ts
@@ -1,2 +1,3 @@
 export * from './apiWithoutMethod'
 export * from './rateLimiter'
+export * from './strictTransportSecurity'

--- a/src/rules/security/strictTransportSecurity.test.ts
+++ b/src/rules/security/strictTransportSecurity.test.ts
@@ -1,0 +1,96 @@
+import type { SFCDescriptor } from '@vue/compiler-sfc'
+import { describe, expect, it } from 'vitest'
+import { checkStrictTransportSecurity, reportStrictTransportSecurity } from './strictTransportSecurity'
+
+describe('checkStrictTransportSecurity', () => {
+  it('should not report when nuxt.config has Strict-Transport-Security header string', () => {
+    const descriptor = {
+      source: `
+        export default defineNuxtConfig({
+          nitro: {
+            routeRules: {
+              '/**': {
+                headers: {
+                  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+                },
+              },
+            },
+          },
+        })
+      `,
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'nuxt.config.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
+  it('should not report when nuxt.config has HSTS configured via strictTransportSecurity camelCase', () => {
+    const descriptor = {
+      source: `
+        export default defineNuxtConfig({
+          security: {
+            headers: {
+              strictTransportSecurity: 'max-age=31536000',
+            },
+          },
+        })
+      `,
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'nuxt.config.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
+  it('should not report when nuxt.config has lowercase strict-transport-security', () => {
+    const descriptor = {
+      source: `
+        export default defineNuxtConfig({
+          headers: {
+            'strict-transport-security': 'max-age=31536000',
+          },
+        })
+      `,
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'nuxt.config.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
+  it('should report when nuxt.config has no HSTS header configured', () => {
+    const descriptor = {
+      source: `
+        export default defineNuxtConfig({
+          modules: ['@nuxtjs/tailwindcss'],
+        })
+      `,
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'nuxt.config.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(1)
+    expect(result[0].description).toContain('Strict-Transport-Security')
+    expect(result[0].message).toContain('No Strict-Transport-Security')
+  })
+
+  it('should not check files that are not nuxt.config', () => {
+    const descriptor = {
+      source: `export default {}`,
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'some-other-file.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(0)
+    expect(result).toStrictEqual([])
+  })
+
+  it('should report when nuxt.config is empty', () => {
+    const descriptor = {
+      source: '',
+    } as SFCDescriptor
+    checkStrictTransportSecurity(descriptor, 'nuxt.config.ts')
+    const result = reportStrictTransportSecurity()
+    expect(result.length).toBe(1)
+    expect(result[0].description).toContain('HSTS')
+  })
+})

--- a/src/rules/security/strictTransportSecurity.ts
+++ b/src/rules/security/strictTransportSecurity.ts
@@ -1,0 +1,52 @@
+import type { SFCDescriptor } from '@vue/compiler-sfc'
+import type { FileCheckResult, Offense } from '../../types'
+
+const results: FileCheckResult[] = []
+
+const resetResults = () => (results.length = 0)
+
+const HSTS_PATTERNS = [
+  'Strict-Transport-Security',
+  'strict-transport-security',
+  'strictTransportSecurity',
+]
+
+const checkStrictTransportSecurity = (descriptor: SFCDescriptor, filePath: string) => {
+  if (!filePath.includes('nuxt.config')) {
+    return
+  }
+
+  const content = descriptor.source
+
+  const hasHSTS = HSTS_PATTERNS.some(pattern => content.includes(pattern))
+
+  if (hasHSTS) {
+    return
+  }
+
+  results.push({
+    filePath,
+    message: `<bg_warn>No Strict-Transport-Security (HSTS) header configured</bg_warn>`,
+  })
+}
+
+const reportStrictTransportSecurity = () => {
+  const offenses: Offense[] = []
+
+  if (results.length > 0) {
+    results.forEach((result) => {
+      offenses.push({
+        file: result.filePath,
+        rule: `<text_info>security ~ Strict-Transport-Security (HSTS)</text_info>`,
+        description: `👉 <text_warn>Add the Strict-Transport-Security header to nuxt.config, or use nuxt-security to enable HSTS protection against downgrade attacks and cookie hijacking.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/security/strict-transport-security.html`,
+        message: `${result.message} 🚨`,
+      })
+    })
+  }
+
+  resetResults()
+
+  return offenses
+}
+
+export { checkStrictTransportSecurity, reportStrictTransportSecurity }

--- a/src/rulesCheck.ts
+++ b/src/rulesCheck.ts
@@ -2,7 +2,7 @@ import type { SFCDescriptor } from '@vue/compiler-sfc'
 import type { OverrideConfig } from './types/Override'
 import { getHasServer, getIsNuxt } from './context'
 import { checkAmountOfComments, checkBigVif, checkBigVshow, checkComplicatedConditions, checkComposableFileName, checkComputedSideEffects, checkCyclomaticComplexity, checkDeepIndentation, checkElseCondition, checkFunctionSize, checkHtmlImageElements, checkHtmlLink, checkHugeFiles, checkIfWithoutCurlyBraces, checkMagicNumbers, checkNestedTernary, checkNoAxiosFetchInNuxt, checkNoDirectDomAccess, checkNoImportant, checkNoInlineStyles, checkNoPropDestructure, checkNoSkippedTests, checkNoTsLang, checkNoVarDeclaration, checkParameterCount, checkPlainScript, checkPropsDrilling, checkRepeatedCss, checkScriptLength, checkShortVariableName, checkTooManyProps, checkVForExpression, checkVForWithIndexKey, checkZeroLengthComparison } from './rules/rrd'
-import { checkApiWithoutMethod, checkRateLimiter } from './rules/security'
+import { checkApiWithoutMethod, checkRateLimiter, checkStrictTransportSecurity } from './rules/security'
 import { checkElementSelectorsWithScoped, checkImplicitParentChildCommunication } from './rules/vue-caution'
 import { checkGlobalStyle, checkSimpleProp, checkSingleNameComponent, checkVforNoKey, checkVifWithVfor } from './rules/vue-essential'
 import { checkElementAttributeOrder, checkTopLevelElementOrder } from './rules/vue-recommended'
@@ -82,6 +82,7 @@ export const checkRules = (descriptor: SFCDescriptor, filePath: string, apply: s
     // security
     apiWithoutMethod: () => getIsNuxt() && checkApiWithoutMethod(descriptor, filePath),
     rateLimiter: () => getHasServer() && getIsNuxt() && checkRateLimiter(descriptor, filePath),
+    strictTransportSecurity: () => getIsNuxt() && checkStrictTransportSecurity(descriptor, filePath),
   }
 
   // Run the checks for each applied rule or ruleset

--- a/src/rulesReport.ts
+++ b/src/rulesReport.ts
@@ -2,7 +2,7 @@ import type { GroupBy, Health, Offense, OffensesGrouped, OutputLevel, ReportFunc
 import type { OverrideConfig } from './types/Override'
 import type { ReportOutput } from './types/ReportOutput'
 import { reportAmountOfComments, reportBigVif, reportBigVshow, reportComplicatedConditions, reportComposableFileName, reportComputedSideEffects, reportCyclomaticComplexity, reportDeepIndentation, reportElseCondition, reportFunctionSize, reportHtmlImageElements, reportHtmlLink, reportHugeFiles, reportIfWithoutCurlyBraces, reportMagicNumbers, reportNestedTernary, reportNoAxiosFetchInNuxt, reportNoDirectDomAccess, reportNoImportant, reportNoInlineStyles, reportNoPropDestructure, reportNoSkippedTests, reportNoTsLang, reportNoVarDeclaration, reportParameterCount, reportPlainScript, reportPropsDrilling, reportRepeatedCss, reportScriptLength, reportShortVariableName, reportTooManyProps, reportVForExpression, reportVForWithIndexKey, reportZeroLengthComparison } from './rules/rrd'
-import { reportApiWithoutMethod, reportRateLimiter } from './rules/security'
+import { reportApiWithoutMethod, reportRateLimiter, reportStrictTransportSecurity } from './rules/security'
 import { reportElementSelectorsWithScoped, reportImplicitParentChildCommunication } from './rules/vue-caution'
 import { reportGlobalStyle, reportSimpleProp, reportSingleNameComponent, reportVforNoKey, reportVifWithVfor } from './rules/vue-essential'
 import { reportElementAttributeOrder, reportTopLevelElementOrder } from './rules/vue-recommended'
@@ -97,6 +97,7 @@ export const reportRules = (groupBy: GroupBy, sortBy: SortBy, level: OutputLevel
   // security rules
   processOffenses(reportApiWithoutMethod)
   processOffenses(reportRateLimiter)
+  processOffenses(reportStrictTransportSecurity)
 
   // Sort offenses grouped by key based on the `sortBy` parameter
   const sortedKeys = Object.keys(offensesGrouped).sort((a, b) => {


### PR DESCRIPTION
### Summary
Adds a new security rule that checks for the Strict-Transport-Security (HSTS) header in Nuxt projects.

### Description
This rule scans `nuxt.config` files for HSTS header configuration. It detects three patterns:
- `Strict-Transport-Security` (standard header name)
- `strict-transport-security` (lowercase)
- `strictTransportSecurity` (camelCase, used by nuxt-security)

If none are found, it reports the file and suggests adding the header or using [nuxt-security](https://nuxt-security.vercel.app/) as a solution.

**Files changed:**
- `src/rules/security/strictTransportSecurity.ts` — new rule implementation
- `src/rules/security/strictTransportSecurity.test.ts` — 6 unit tests covering all patterns
- `src/rules/security/index.ts` — export added
- `src/rules/rules.ts` — rule registered in security ruleset
- `src/rulesCheck.ts` — check function wired in (Nuxt-only)
- `src/rulesReport.ts` — report function wired in
- `docs/.vitepress/config.ts` — sidebar entry
- `docs/rules/security/index.md` — rule list entry
- `docs/rules/security/strict-transport-security.md` — full documentation with fix examples

### Related Issues
Closes #309

### Type of Change
- [x] New feature (non-breaking change which adds functionality)