### PR TITLE
fix(no-prop-destructure): allow reactive props destructuring in Vue 3.5

### DIFF
--- a/docs/rules/rrd/no-prop-destructure.md
+++ b/docs/rules/rrd/no-prop-destructure.md
@@ -1,29 +1,46 @@
-# Props Destructing break reactivity
+# Runtime Props Destructuring Breaks Reactivity
 
-In Vue, destructuring props lead to reactivity issues and should be avoided. Destructuring props will inadvertently break Vue's reactivity system because Vue relies on accessing properties through the original props object to maintain reactivity.
+Vue 3.5 introduced Reactive Props Destructure: variables destructured directly from the `defineProps()` compiler macro remain reactive. Destructuring a runtime `props` object still creates plain variables and loses reactivity.
 
-## 📖 What is props destructuring?
+## 📖 What is unsafe props destructuring?
 
-Props destructuring refers to the practice of extracting individual properties from a props object within a Vue component. This is often done to simplify code and make it more readable by directly accessing specific props.
-
-### Vue Specific Considerations:
-
-While destructuring can simplify code in many cases, it lead to issues with Vue's reactivity system. When props are destructured, Vue not be able to track changes to the destructured properties. This is because destructuring creates separate variables that do not maintain a reactive relationship with the original props object.
+The Vue compiler can transform a direct `defineProps()` destructure in Vue 3.5+, but it cannot preserve reactivity when a props object is assigned first and destructured in a separate statement.
 
 As a result:
 
-- Reactivity Issues: Changes to the original props will not be reflected in the destructured variables, potentially leading to outdated or incorrect data being used in the component.
-- Data Flow: Destructuring can obscure the data flow within the component, making it harder to trace how props are being used or modified.
+- Changes to the original prop are not reflected in variables destructured from the runtime object.
+- The code looks reactive even though it holds a stale value, which makes data flow harder to reason about.
 
-## ❓ Why it's good to follow this rule?
+## ❓ Why is this rule useful?
 
-Destructuring props is not recommended in Vue due to the fact of breaking reactivity and making data flow less transparent. It is best to use the props object directly to ensure correct functionality and maintainability.
+This rule catches only runtime props-object destructuring. Direct `defineProps()` destructuring is intentionally allowed for Vue 3.5+ projects.
 
-## 😱 Examples of code for which this rule will throw a warning
+## 😱 Example that triggers a warning
 
 ::: warning
-The following code destructures props in a Vue component, which will lead to reactivity issues.
+The following separate destructuring statement loses reactivity.
 :::
+
+```vue
+<script setup>
+const props = defineProps(['propA', 'propB'])
+const { propA, propB } = props
+</script>
+```
+
+## 🤩 How to fix it
+
+Access values through the runtime props object:
+
+```vue
+<script setup>
+const props = defineProps(['propA', 'propB'])
+
+console.log(props.propA, props.propB)
+</script>
+```
+
+In Vue 3.5+, direct compiler-supported destructuring is also reactive:
 
 ```vue
 <script setup>
@@ -31,17 +48,4 @@ const { propA, propB } = defineProps(['propA', 'propB'])
 </script>
 ```
 
-## 🤩 How to fix it?
-
-::: tip
-Do not destructure props in Vue components. Instead, access props directly from the `props` object.
-:::
-
-```vue
-<script setup>
-const props = defineProps(['propA', 'propB'])
-
-const propA = props.propA
-const propB = props.propB
-</script>
-```
+See Vue's [Reactive Props Destructure documentation](https://vuejs.org/guide/components/props.html#reactive-props-destructure) for details.

--- a/src/rules/rrd/noPropDestructure.test.ts
+++ b/src/rules/rrd/noPropDestructure.test.ts
@@ -2,131 +2,102 @@ import type { SFCScriptBlock } from '@vue/compiler-sfc'
 import { describe, expect, it } from 'vitest'
 import { checkNoPropDestructure, reportNoPropDestructure } from './noPropDestructure'
 
+const description = `👉 <text_warn>Avoid destructuring a runtime props object because it loses reactivity. Access \`props.propName\` instead, or destructure directly from \`defineProps()\` in Vue 3.5+.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`
+
 describe('checkNoPropDestructure', () => {
-  it('should not report files without props destructuring', () => {
+  it('does not report access through the props object', () => {
     const script = {
       content: `
       <script setup>
         const props = defineProps();
-        const myProp = props.myprop;
+        const myProp = props.myProp;
       </script>
       `,
     } as SFCScriptBlock
-    const fileName = 'noPropDestructure.vue'
-    checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(0)
-    expect(result).toStrictEqual([])
+
+    checkNoPropDestructure(script, 'safe-props-access.vue')
+
+    expect(reportNoPropDestructure()).toStrictEqual([])
   })
 
-  it('should report files with single props destructuring using defineProps', () => {
+  it('does not report Vue 3.5 reactive props destructure', () => {
     const script = {
       content: `
       <script setup>
-        const { propA } = defineProps();
+        const { propA = 'default', propB } = defineProps<{ propA?: string, propB: string }>();
       </script>
       `,
     } as SFCScriptBlock
-    const fileName = 'noPropDestructure-single.vue'
+
+    checkNoPropDestructure(script, 'reactive-props-destructure.vue')
+
+    expect(reportNoPropDestructure()).toStrictEqual([])
+  })
+
+  it('reports destructuring from a runtime props object', () => {
+    const script = {
+      content: `
+      <script setup>
+        const props = defineProps();
+        const { propA } = props;
+      </script>
+      `,
+    } as SFCScriptBlock
+    const fileName = 'runtime-props-destructure.vue'
+
     checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(1)
-    expect(result).toStrictEqual([
+
+    expect(reportNoPropDestructure()).toStrictEqual([
       {
         file: fileName,
         rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
-        message: `line #3 <bg_warn>props destructuring found: const { propA } = defineProps()</bg_warn> 🚨`,
+        description,
+        message: `line #4 <bg_warn>props destructuring found: const { propA } = props</bg_warn> 🚨`,
       },
     ])
   })
 
-  it('should report files with multiple props destructuring instances using defineProps', () => {
+  it('reports multiple runtime destructures including defaults', () => {
     const script = {
       content: `
       <script setup>
-        const { propA } = defineProps();
-        const { propB } = defineProps();
+        const props = defineProps();
+        const { propA = 'default' } = props;
+        let { propB } = props;
       </script>
       `,
     } as SFCScriptBlock
-    const fileName = 'noPropDestructure-multiple.vue'
+    const fileName = 'multiple-runtime-props-destructures.vue'
+
     checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(2)
-    expect(result).toStrictEqual([
+
+    expect(reportNoPropDestructure()).toStrictEqual([
       {
         file: fileName,
         rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
-        message: `line #3 <bg_warn>props destructuring found: const { propA } = defineProps()</bg_warn> 🚨`,
+        description,
+        message: `line #4 <bg_warn>props destructuring found: const { propA = 'default' } = props</bg_warn> 🚨`,
       },
       {
         file: fileName,
         rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
-        message: `line #4 <bg_warn>props destructuring found: const { propB } = defineProps()</bg_warn> 🚨`,
+        description,
+        message: `line #5 <bg_warn>props destructuring found: let { propB } = props</bg_warn> 🚨`,
       },
     ])
   })
 
-  it('should report files with props destructuring and default values using defineProps', () => {
+  it('does not report destructuring unrelated values', () => {
     const script = {
       content: `
       <script setup>
-        const { propA = 'default', propB } = defineProps();
+        const { value } = ref('value');
       </script>
       `,
     } as SFCScriptBlock
-    const fileName = 'noPropDestructure-default.vue'
-    checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(1)
-    expect(result).toStrictEqual([
-      {
-        file: fileName,
-        rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
-        message: `line #3 <bg_warn>props destructuring found: const { propA = 'default', propB } = defineProps()</bg_warn> 🚨`,
-      },
-    ])
-  })
 
-  it('should not report files with destructuring of other variables', () => {
-    const script = {
-      content: `
-      <script setup>
-        const { someVar } = ref('value');
-      </script>
-      `,
-    } as SFCScriptBlock
-    const fileName = 'noPropDestructure-other-vars.vue'
-    checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(0)
-    expect(result).toStrictEqual([])
-  })
+    checkNoPropDestructure(script, 'unrelated-destructure.vue')
 
-  it('should report files where props are destructured and used in expressions', () => {
-    const script = {
-      content: `
-      <script setup>
-        const { propA } = defineProps();
-        console.log(propA);
-      </script>
-      `,
-    } as SFCScriptBlock
-    const fileName = 'noPropDestructure-expressions.vue'
-    checkNoPropDestructure(script, fileName)
-    const result = reportNoPropDestructure()
-    expect(result.length).toBe(1)
-    expect(result).toStrictEqual([
-      {
-        file: fileName,
-        rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
-        message: `line #3 <bg_warn>props destructuring found: const { propA } = defineProps()</bg_warn> 🚨`,
-      },
-    ])
+    expect(reportNoPropDestructure()).toStrictEqual([])
   })
 })

--- a/src/rules/rrd/noPropDestructure.ts
+++ b/src/rules/rrd/noPropDestructure.ts
@@ -13,8 +13,10 @@ const checkNoPropDestructure = (script: SFCScriptBlock | null, filePath: string)
     return
   }
 
-  // eslint-disable-next-line regexp/no-super-linear-backtracking
-  const regex = /(?:const|let)\s*\{\s*([^}]+?)\s*\}\s*=\s*(?:defineProps|props)\s*\(\s*(?:(?:\[[^\]]*\]|\{[^}]*\})\s*)?\)/g
+  // Vue 3.5 makes variables destructured directly from the defineProps macro
+  // reactive at compile time. Destructuring a runtime props object still loses
+  // reactivity, so only report that unsafe form.
+  const regex = /(?:const|let)\s*\{[^}]+\}\s*=\s*props\b/g
 
   const content = skipComments(script.content)
   const matches = content.match(regex)
@@ -36,7 +38,7 @@ const reportNoPropDestructure = () => {
       offenses.push({
         file: result.filePath,
         rule: `<text_info>rrd ~ no Prop Destructure</text_info>`,
-        description: `👉 <text_warn>Avoid destructuring props in the setup function. Use \`props.propName\` instead of \`const { propName } = defineProps()\`.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
+        description: `👉 <text_warn>Avoid destructuring a runtime props object because it loses reactivity. Access \`props.propName\` instead, or destructure directly from \`defineProps()\` in Vue 3.5+.</text_warn> See: https://vue-mess-detector.webmania.cc/rules/rrd/no-props-destructure.html`,
         message: `${result.message} 🚨`,
       })
     })


### PR DESCRIPTION
## Problem

Vue 3.5 makes variables destructured directly from `defineProps()` reactive at compile time. The rule still reported this supported syntax, creating false positives in current Vue projects.

Destructuring from a runtime `props` object remains non-reactive and should still be reported.

## Solution

- Allow direct `defineProps()` destructuring supported by Vue 3.5.
- Continue reporting destructuring from runtime props objects.
- Add regression coverage for both safe and unsafe forms.
- Update the rule documentation to explain the distinction.

## Verification

- `yarn vitest run src/rules/rrd/noPropDestructure.test.ts --reporter=dot` — 5 tests passed
- ESLint passed for the implementation and test
- `git diff --check` passed

Fixes #220
